### PR TITLE
Force unix-style line ending.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
On windows, files are checked out with the windows line ending CRLF. When building the container these files are copied to the unix container resulting in a failing build. This closes #11.